### PR TITLE
[BUGFIX] Allow render large simulation file

### DIFF
--- a/intellij-plugin/CHANGELOG.md
+++ b/intellij-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/Lemick/hoverfly-ui/commits
 
+## [1.0.2]
+
+- Fix render large simulation file
+
 ## [1.0.1]
 
 - Fix icon display (seems to fix a IDE render issue)

--- a/intellij-plugin/gradle.properties
+++ b/intellij-plugin/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup=com.lemick
 pluginName=hoverfly-ui-intellij-plugin
 pluginRepositoryUrl=https://github.com/Lemick/hoverfly-ui
-pluginVersion=1.0.1
+pluginVersion=1.0.2
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=222
 pluginUntilBuild=232.*

--- a/intellij-plugin/src/main/kotlin/com/github/lemick/hoverflyui/intellij/plugin/SimulationsFileEditor.kt
+++ b/intellij-plugin/src/main/kotlin/com/github/lemick/hoverflyui/intellij/plugin/SimulationsFileEditor.kt
@@ -16,6 +16,7 @@ import org.cef.CefApp
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
 import java.beans.PropertyChangeListener
+import java.util.Base64
 import javax.swing.JComponent
 
 internal class SimulationsFileEditor(private val project: Project, private val file: VirtualFile) :
@@ -80,13 +81,7 @@ internal class SimulationsFileEditor(private val project: Project, private val f
     }
 
     private fun getContent(): String {
-        return String(file.contentsToByteArray())
-            .replace("\"", "\\\"") // Escape double quotes
-            .replace("'", "\\'") // Escape single quotes
-            .replace("/", "\\/") // Escape slash
-            .replace("\n", "\\\n") // Escape LF of file
-            .replace("\r", "\\\r") // Escape CR of file
-            .replace("\\n", "\\\\n") // Escape already escaped EOL from embedded JSON
+        return Base64.getEncoder().encodeToString(file.contentsToByteArray());
     }
 
     private fun enablePluginModeUI() {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
   if (window.hoverflyUi_enablePluginMode) {
     return (
       <PluginEditorPage
-        simulationJson={simulationData}
+        simulationData={simulationData}
         onSimulationUpdate={window.hoverflyUi_onUiSimulationChange}
       />
     );

--- a/ui/src/components/pages/PluginEditorPage.tsx
+++ b/ui/src/components/pages/PluginEditorPage.tsx
@@ -4,7 +4,7 @@ import { RequestResponsePair } from '../../types/hoverfly';
 import { parse, stringify } from '../../services/json-service';
 
 type PluginEditorPageProps = {
-  simulationJson?: string;
+  simulationData?: string;
   onSimulationUpdate?: (simulationJson: string) => void;
 };
 
@@ -12,10 +12,10 @@ type PluginEditorPageProps = {
  * A light page that only provides the UI to edit simulations.
  */
 export default function PluginEditorPage({
-  simulationJson,
+  simulationData,
   onSimulationUpdate
 }: PluginEditorPageProps) {
-  const parsedJson = parse(simulationJson);
+  const parsedJson = parse(atob(simulationData||""));
   // TODO provide a way to start from scratch
 
   function onChangeFromForms(updatedPairs: RequestResponsePair[]) {


### PR DESCRIPTION
### Overview

Large simulation file rendering fail due to invalid escaping.
Switch to base64 encoding to send simulation file to browser.