### PR TITLE
[FEATURE] Encode the request body with unicode (very simply) and support UTF-8 charset in hoverfly file

### DIFF
--- a/ui/src/components/forms/matchers/FieldMatchersForm.tsx
+++ b/ui/src/components/forms/matchers/FieldMatchersForm.tsx
@@ -14,6 +14,8 @@ import { Button } from '@/components/ui/Button';
 import { TrashIcon, GearIcon } from '@radix-ui/react-icons';
 import { FormControl } from '@/components/utilities/FormControl';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
+import ResponseBodyEditor from '../ResponseBodyEditor';
+import { prettify } from '@/services/json-service';
 
 type Props = {
   id: string;
@@ -78,14 +80,28 @@ const FieldMatcherForm = ({
 
         <FormControl direction="column" className="w-full">
           <Label htmlFor={generateDomId('matcher-value')}>Value</Label>
-          <Input
-            id={generateDomId('matcher-value')}
-            type="text"
-            name="value"
-            placeholder={valuePlaceholder}
-            value={fieldMatcher.value}
-            onChange={(e) => handleMatcherChange('value', e.target.value)}
-          />
+          {fieldMatcher.matcher === 'json' || fieldMatcher.matcher === 'jsonPartial' ? (
+            <div className="flex flex-col gap-2 w-full">
+              <ResponseBodyEditor
+                value={prettify(fieldMatcher.value)}
+                onChange={(e) =>
+                  handleMatcherChange(
+                    'value',
+                    e.replaceAll('<', '\\u003c').replaceAll('>', '\\u003e')
+                  )
+                }
+              />
+            </div>
+          ) : (
+            <Input
+              id={generateDomId('matcher-value')}
+              type="text"
+              name="value"
+              placeholder={valuePlaceholder}
+              value={fieldMatcher.value}
+              onChange={(e) => handleMatcherChange('value', e.target.value)}
+            />
+          )}
         </FormControl>
 
         <Popover>

--- a/ui/src/components/pages/PluginEditorPage.tsx
+++ b/ui/src/components/pages/PluginEditorPage.tsx
@@ -7,6 +7,12 @@ import { initHoverflySimulation } from '@/services/request-matcher-service';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { TypographyH2 } from '@/components/ui/Typography';
 
+function b64DecodeUnicode(value: string) {
+  return decodeURIComponent(Array.prototype.map.call(atob(value), function(c) {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+  }).join(''))
+}
+
 type PluginEditorPageProps = {
   simulationData?: string;
   onSimulationUpdate?: (simulationJson: string) => void;
@@ -19,7 +25,7 @@ export default function PluginEditorPage({
   simulationData,
   onSimulationUpdate = () => {}
 }: PluginEditorPageProps) {
-  const parsedJson = parse(atob(simulationData || ''));
+  const parsedJson = parse(b64DecodeUnicode(simulationData || ''));
 
   function onChangeFromForms(updatedPairs: RequestResponsePair[]) {
     const updatedSimulation = {

--- a/ui/src/types/hoverfly.ts
+++ b/ui/src/types/hoverfly.ts
@@ -18,7 +18,7 @@ export type LogNormalDelay = {
 };
 
 export type FieldMatcher = {
-  matcher?: 'exact' | 'glob' | 'regex' | 'json';
+  matcher?: 'exact' | 'glob' | 'regex' | 'json' | 'jsonPartial';
   value: string;
   config?: MatcherConfig;
   doMatch?: FieldMatcher;


### PR DESCRIPTION
Hello @Lemick 

First of all, thank you for your really cool plugin 🙂 

I propose a very simply implementation of my needs.
I have to encode some HTML in JSON in my request bodies and i simply replace '<' and '>' by their unicode.

I suggest you to use Monaco in request body matcher if it's JSON.

And last but not least, I tried to support UTF8 in the Intellij Plugin.